### PR TITLE
Task #23

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -31,11 +31,11 @@ data:
         {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundPorts\") -]]" }}
         - "-o"
         {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundPorts\"  ]]\"" }}
-        {{ "[[ end -]]" }}
         {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundPorts\") -]]" }}
         - "-z"
         {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundPorts\"  ]]\"" }}
-        {{ "[[ end -]]" }}    
+        {{ "[[ end -]]" }}
+        {{ "[[ else -]]" }}
         - "-i"
         {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\") -]]" }}
         {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\"  ]]\"" }}
@@ -47,6 +47,7 @@ data:
         {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundIPRanges\"  ]]\"" }}
         {{ "[[ else -]]" }}
         - "{{ .Values.global.proxy.excludeIPRanges }}"
+        {{ "[[ end -]]" }}
         {{ "[[ end -]]" }}
         - "-b"
         {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeInboundPorts\") -]]" }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -28,6 +28,14 @@ data:
         - 1337
         - "-m"
         - {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
+        {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundPorts\") -]]" }}
+        - "-o"
+        {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundPorts\"  ]]\"" }}
+        {{ "[[ end -]]" }}
+        {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundPorts\") -]]" }}
+        - "-z"
+        {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/excludeOutboundPorts\"  ]]\"" }}
+        {{ "[[ end -]]" }}    
         - "-i"
         {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\") -]]" }}
         {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\"  ]]\"" }}

--- a/istioctl/cmd/istioctl/kubeinject.go
+++ b/istioctl/cmd/istioctl/kubeinject.go
@@ -114,6 +114,8 @@ func validateFlags() error {
 		err = multierr.Append(err, errors.New("--meshConfigFile or --meshConfigMapName must be set"))
 	}
 
+	err = multierr.Append(err, inject.ValidateIncludeOutboundPorts(includeOutboundPorts))
+	err = multierr.Append(err, inject.ValidateExcludeOutboundPorts(excludeOutboundPorts))
 	err = multierr.Append(err, inject.ValidateIncludeIPRanges(includeIPRanges))
 	err = multierr.Append(err, inject.ValidateExcludeIPRanges(excludeIPRanges))
 	err = multierr.Append(err, inject.ValidateIncludeInboundPorts(includeInboundPorts))
@@ -122,19 +124,21 @@ func validateFlags() error {
 }
 
 var (
-	hub                 string
-	tag                 string
-	sidecarProxyUID     uint64
-	verbosity           int
-	versionStr          string // override build version
-	enableCoreDump      bool
-	imagePullPolicy     string
-	includeIPRanges     string
-	excludeIPRanges     string
-	includeInboundPorts string
-	excludeInboundPorts string
-	debugMode           bool
-	emitTemplate        bool
+	hub                  string
+	tag                  string
+	sidecarProxyUID      uint64
+	verbosity            int
+	versionStr           string // override build version
+	enableCoreDump       bool
+	imagePullPolicy      string
+	includeOutboundPorts string
+	excludeOutboundPorts string
+	includeIPRanges      string
+	excludeIPRanges      string
+	includeInboundPorts  string
+	excludeInboundPorts  string
+	debugMode            bool
+	emitTemplate         bool
 
 	inFilename          string
 	outFilename         string
@@ -276,6 +280,8 @@ istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml --injectConf
 					EnableCoreDump:      enableCoreDump,
 					Mesh:                meshConfig,
 					ImagePullPolicy:     imagePullPolicy,
+					IncludeOutboundPorts: includeOutboundPorts,
+					ExcludeOutboundPorts: excludeOutboundPorts,
 					IncludeIPRanges:     includeIPRanges,
 					ExcludeIPRanges:     excludeIPRanges,
 					IncludeInboundPorts: includeInboundPorts,
@@ -366,6 +372,13 @@ func init() {
 	injectCmd.PersistentFlags().StringVar(&imagePullPolicy, "imagePullPolicy", inject.DefaultImagePullPolicy,
 		"Sets the container image pull policy. Valid options are Always,IfNotPresent,Never."+
 			"The default policy is IfNotPresent.")
+	injectCmd.PersistentFlags().StringVar(&includeOutboundPorts, "includeOutboundPorts", inject.DefaultIncludeOutboundPorts,
+		"Comma separated list of outbound ports for which traffic is to be redirected to Envoy. All ports can "+
+			"be redirected with the wildcard character '*'.")
+	injectCmd.PersistentFlags().StringVar(&excludeOutboundPorts, "excludeOutboundPorts", "",
+		"Comma separated list of outbound ports. If set, inbound traffic will not be redirected for those "+
+			"ports. Exclusions are only applied if configured to redirect all outbound traffic. By default, no ports "+
+			"are excluded.")
 	injectCmd.PersistentFlags().StringVar(&includeIPRanges, "includeIPRanges", inject.DefaultIncludeIPRanges,
 		"Comma separated list of IP ranges in CIDR form. If set, only redirect outbound traffic to Envoy for "+
 			"these IP ranges. All outbound traffic can be redirected with the wildcard character '*'.")

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -287,24 +287,22 @@ done
 iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
 
 if [ -n "${OUTBOUND_PORTS_INCLUDE}" ]; then
-  if [ -n "${OUTBOUND_PORTS_INCLUDE}" ]; then
-    if [ "${OUTBOUND_PORTS_INCLUDE}" == "*" ]; then
-      # Redirect exclusions must be applied before inclusions.
-      if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
-        for port in ${OUTBOUND_PORTS_EXCLUDE}; do
-          iptables -t nat -A ISTIO_OUTPUT -p tcp --dport ${port} -j RETURN
-        done
-      fi
-      # Redirect remaining outbound traffic to Envoy
-      iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
-    else
-      # User has specified a non-empty list of ports to be redirected to Envoy.
-      for port in ${OUTBOUND_PORTS_INCLUDE}; do
-        iptables -t nat -A ISTIO_OUTPUT -p tcp --dport ${port} -j ISTIO_REDIRECT
+  if [ "${OUTBOUND_PORTS_INCLUDE}" == "*" ]; then
+    # Redirect exclusions must be applied before inclusions.
+    if [ -n "${OUTBOUND_PORTS_EXCLUDE}" ]; then
+      for port in ${OUTBOUND_PORTS_EXCLUDE}; do
+        iptables -t nat -A ISTIO_OUTPUT -p tcp --dport ${port} -j RETURN
       done
-      # All other traffic is not redirected.
-      iptables -t nat -A ISTIO_OUTPUT -j RETURN
     fi
+    # Redirect remaining outbound traffic to Envoy
+    iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
+  else
+    # User has specified a non-empty list of ports to be redirected to Envoy.
+    for port in ${OUTBOUND_PORTS_INCLUDE}; do
+      iptables -t nat -A ISTIO_OUTPUT -p tcp --dport ${port} -j ISTIO_REDIRECT
+    done
+    # All other traffic is not redirected.
+    iptables -t nat -A ISTIO_OUTPUT -j RETURN
   fi
 else
   if [ "${OUTBOUND_IP_RANGES_INCLUDE}" == "*" ]; then


### PR DESCRIPTION
add OutboudPorts policy like InboundPorts policy
annotations can be add to yaml and then sidecar inject will follow this policy

annotations:
        traffic.sidecar.istio.io/includeOutboundPorts: '*'
        traffic.sidecar.istio.io/excludeOutboundPorts: '80'

when OutboudPorts policy has been set, OutboundIPRanges policy will be disabled