### PR TITLE
fix wrong error log when failed to create Zookeeper controller

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -676,7 +676,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 			zkctl, zkerr := zookeeper.NewController(
 				args.Service.Zookeeper.ServerURL, args.Service.Zookeeper.Root)
 			if zkerr != nil {
-				return fmt.Errorf("failed to create Consul controller: %v", zkerr)
+				return fmt.Errorf("failed to create Zookeeper controller: %v", zkerr)
 			}
 			serviceControllers.AddRegistry(
 				aggregate.Registry{


### PR DESCRIPTION
fix wrong error log when failed to create Zookeeper controller